### PR TITLE
XCode 7 Compatibility UUID's

### DIFF
--- a/TimePlugin/TimePlugin-Info.plist
+++ b/TimePlugin/TimePlugin-Info.plist
@@ -42,6 +42,7 @@
 		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
+		<string>0420B86A-AA43-4792-9ED0-6FE0F2B16A13</string>
 	</array>
 </dict>
 </plist>

--- a/TimePlugin/TimePlugin-Info.plist
+++ b/TimePlugin/TimePlugin-Info.plist
@@ -43,6 +43,7 @@
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
 		<string>0420B86A-AA43-4792-9ED0-6FE0F2B16A13</string>
+		<string>7265231C-39B4-402C-89E1-16167C4CC990</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
I would like to add Xcode 7.0 and 7.1 compatibility UUID's. 
This will allow to run plugin under XCode 7.
